### PR TITLE
Always include the error code, in this case 404.

### DIFF
--- a/404.html
+++ b/404.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>Page Not Found</title>
+    <title>404 - Page Not Found</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <style>
 
@@ -53,7 +53,7 @@
     </style>
 </head>
 <body>
-    <h1>Page Not Found</h1>
+    <h1>404 - Page Not Found</h1>
     <p>Sorry, but the page you were trying to view does not exist.</p>
 </body>
 </html>


### PR DESCRIPTION
In 404.html: I added 404 where needed; beside "Page Not Found" in the <title> tag as well as in the body. For development and user support reasons it is always important to give an error code for easier resolutions to site issues.